### PR TITLE
Log exceptions

### DIFF
--- a/src/Serilog.Sinks.YandexCloud.Tests/Unit/EventPropertiesRenderingTests.cs
+++ b/src/Serilog.Sinks.YandexCloud.Tests/Unit/EventPropertiesRenderingTests.cs
@@ -82,4 +82,18 @@ public class EventPropertiesRenderingTests
         Assert.That(listValue.Values[1].StringValue, Is.EqualTo("another text"));
     }
 
+    [Test]
+    public void ExceptionShouldBeConvertedToProtobuf()
+    {
+        var messageTemplate = new MessageTemplate(Array.Empty<MessageTemplateToken>());
+
+        var serilogEntry = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Error, new Exception("ErrorMessage"),
+            messageTemplate, Enumerable.Empty<LogEventProperty>());
+
+        var yandexEntry = serilogEntry.ToIncomingLogEntry();
+
+        Assert.That(yandexEntry.JsonPayload.Fields.ContainsKey("Exception"));
+
+        Assert.That(yandexEntry.JsonPayload.Fields["Exception"].StringValue, Contains.Substring("ErrorMessage"));
+    }
 }

--- a/src/Serilog.Sinks.YandexCloud/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.YandexCloud/LogEventExtensions.cs
@@ -57,6 +57,11 @@ namespace Serilog.Sinks.YandexCloud
                 properties.Add(key, ToStructure(entry.Properties[key]));
             }
 
+            if (entry.Exception is not null)
+            {
+                properties.Add(nameof(entry.Exception), entry.Exception.ToString());
+            }
+
             return Struct.Parser.ParseJson(JsonSerializer.Serialize(properties));
         }
 


### PR DESCRIPTION
```json
{
  "Exception": "System.Exception: Test\r\n   at MyApp.Controllers.MyController.Get() in C:\\MyApp\\Controllers\\MyController.cs:line 32\r\n   at lambda_method54(Closure, Object)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.AwaitableObjectResultExecutor.Execute(ActionContext actionContext, IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask`1 actionResultValueTask)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\r\n--- End of stack trace from previous location ---\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|20_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\r\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)\r\n   at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|7_0(Endpoint endpoint, Task requestTask, ILogger logger)\r\n   at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)\r\n   at Swashbuckle.AspNetCore.SwaggerUI.SwaggerUIMiddleware.Invoke(HttpContext httpContext)\r\n   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)\r\n   at Serilog.AspNetCore.RequestLoggingMiddleware.Invoke(HttpContext httpContext)\r\n   at Reputation.Logging.RequestLogEnrichmentMiddleware.InvokeAsync(HttpContext httpContext) in D:\\GitReps\\logging\\Reputation.Logging.Http\\RequestLogEnrichmentMiddleware.cs:line 41\r\n   at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)\r\n   at Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddlewareImpl.Invoke(HttpContext context)",
  "StatusCode": "500"
  ...
}
```